### PR TITLE
Fixed problem based on cultures using different decimal separators.

### DIFF
--- a/Baileysoft.Games.Data/Games.cs
+++ b/Baileysoft.Games.Data/Games.cs
@@ -29,6 +29,7 @@ namespace Baileysoft.Games.Data
     using System.IO;
     using System.Reflection;
     using System.Xml.Linq;
+    using System.Globalization;
 
     /// <summary>
     /// Games abstraction
@@ -69,7 +70,7 @@ namespace Baileysoft.Games.Data
             var xdoc = XDocument.Load(IndexFile);
             var xAttribute = xdoc.Root?.Attribute("revision");
             if (xAttribute != null)
-                Revision = double.Parse(xAttribute.Value);
+                Revision = double.Parse(xAttribute.Value, CultureInfo.InvariantCulture);
 
             var gameRepo = new GameRepository(IndexFile);
             AddRange(gameRepo.Get(Game.Keys.Title, GameRepository.SortOrder.ASCENDING));


### PR DESCRIPTION
Double.Parse should always specify culture when the format of the string to be parsed is known. In this case, period is standard in XML so Invariant culture should always work.